### PR TITLE
Fix errors in #include directives

### DIFF
--- a/DROMatic.ino
+++ b/DROMatic.ino
@@ -10,9 +10,9 @@
 #include <SPI.h> //Suppoting lib for SD card
 #include <SD.h> //SD card API
 #include <StandardCplusplus.h> //STD
-#include <StandardCplusplus\vector> //Vectors
-#include <StandardCplusplus\ctime> //Time helper
-#include <ArduinoJson\ArduinoJson.h> //Arduno Json (aka epic)
+#include <vector> //Vectors
+#include <ctime> //Time helper
+#include <ArduinoJson.h> //Arduno Json (aka epic)
 #include <DS3231.h> //Real time clock lib
  
 #include "src\Globals.h" //All temp and PROGMEM global variables

--- a/DROMatic.ino
+++ b/DROMatic.ino
@@ -15,16 +15,16 @@
 #include <ArduinoJson.h> //Arduno Json (aka epic)
 #include <DS3231.h> //Real time clock lib
  
-#include "src\Globals.h" //All temp and PROGMEM global variables
-#include "src\Core.h" //All core functions and variables
-#include "src\Crops.h" //All crop functions and variables
-#include "src\Pumps.h" //All pump functions and variables
-#include "src\Regimens.h" //All session functions and variables
-#include "src\Screens.h" //All screen functions and variables
-#include "src\Menus.h" //All menu functions and variables
-#include "src\DatesTime.h" //All date & time functions and variables
-#include "src\Irrigation.h" //All irrigation related functions and variables
-#include "src\Timers.h" //All timer related functions and variables
+#include "src/Globals.h" //All temp and PROGMEM global variables
+#include "src/Core.h" //All core functions and variables
+#include "src/Crops.h" //All crop functions and variables
+#include "src/Pumps.h" //All pump functions and variables
+#include "src/Regimens.h" //All session functions and variables
+#include "src/Screens.h" //All screen functions and variables
+#include "src/Menus.h" //All menu functions and variables
+#include "src/DatesTime.h" //All date & time functions and variables
+#include "src/Irrigation.h" //All irrigation related functions and variables
+#include "src/Timers.h" //All timer related functions and variables
 
 //OS main setup
 void setup()

--- a/src/Core.h
+++ b/src/Core.h
@@ -10,7 +10,7 @@
 
 #include "Globals.h"
 #include <Wire.h>
-#include <ArduinoJson\ArduinoJson.h> //Arduno Json (aka epic)
+#include <ArduinoJson.h> //Arduno Json (aka epic)
 
 
 extern JsonObject& getCoreData(JsonBuffer& b);

--- a/src/Crops.h
+++ b/src/Crops.h
@@ -8,7 +8,7 @@
 #ifndef _CROPS_h
 #define _CROPS_h
 #include "Globals.h"
-#include <ArduinoJson\ArduinoJson.h> //Arduno Json (aka epic)
+#include <ArduinoJson.h> //Arduno Json (aka epic)
 
 extern String cropName;
 

--- a/src/Globals.h
+++ b/src/Globals.h
@@ -12,7 +12,7 @@
 #include <SPI.h> //Suppoting lib for SD card
 #include <SD.h> //SD card API
 #include <StandardCplusplus.h> //STD
-#include <StandardCplusplus\vector> //Vectors
+#include <vector> //Vectors
 #include <LiquidCrystal.h> //lib for interfacing with LCD screen
 #include <DS3231.h> //Real time clock lib
 #include <Adafruit_NeoPixel.h> //LED lib

--- a/src/Irrigation.h
+++ b/src/Irrigation.h
@@ -7,7 +7,7 @@
 
 #ifndef _IRRIGATION_h
 #define _IRRIGATION_h
-#include <ArduinoJson\ArduinoJson.h> //Arduno Json (aka epic)
+#include <ArduinoJson.h> //Arduno Json (aka epic)
 
 extern JsonObject& getIrrigationData(JsonBuffer& b);
 extern void setIrrigationData(JsonObject& d);

--- a/src/Pumps.h
+++ b/src/Pumps.h
@@ -8,7 +8,7 @@
 #ifndef _PUMPS_h
 #define _PUMPS_h
 #include "Globals.h"
-#include <ArduinoJson\ArduinoJson.h> //Arduno Json (aka epic)
+#include <ArduinoJson.h> //Arduno Json (aka epic)
 extern byte currentPumpIndex;
 
 //Read & Write from SD

--- a/src/Regimens.h
+++ b/src/Regimens.h
@@ -9,7 +9,7 @@
 #define _SESSIONS_h
 #include "Globals.h"
 #include "Pumps.h"
-#include <ArduinoJson\ArduinoJson.h> //Arduno Json (aka epic)
+#include <ArduinoJson.h> //Arduno Json (aka epic)
 
 extern byte currentRegimenIndex;
 

--- a/src/Timers.h
+++ b/src/Timers.h
@@ -8,7 +8,7 @@
 #ifndef _TIMERS_h
 #define _TIMERS_h
 #include "Globals.h"
-#include <ArduinoJson\ArduinoJson.h> //Arduno Json (aka epic)
+#include <ArduinoJson.h> //Arduno Json (aka epic)
 
 extern byte currentTimerIndex, currentTimerSessionIndex, currentTimerSessionDayIndex;
 


### PR DESCRIPTION
- Remove library folder name from #include directives
- Use cross-platform path separator in #include directives

Partially fixes https://github.com/drolsen/DRO-Matic/issues/125 (the Arduino IDE error).

CC: @abufahad-1